### PR TITLE
CLI-51-Fixed the update checked bug

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -205,7 +205,7 @@ const app = async (argv: any): Promise<void> => {
   // tool
   {
     const toolCommand = commander.command('tool');
-    toolCommand.command('update').description('check if new version is available').action(() => updateCheckCommand.run({ check: true }));
+    toolCommand.command('update').description('check if new version is available').action(() => updateCheckCommand.run());
   }
 
   await commander.execute(argv);

--- a/src/commands/tool/update-check-command.js
+++ b/src/commands/tool/update-check-command.js
@@ -1,0 +1,26 @@
+// @flow
+import logger from '@app/helpers/logger';
+import versionCheck from '@app/helpers/version-check';
+
+// $FlowFixMe
+import packageJson from '@root/package.json';
+
+const updateCheckCommand = async () => {
+  const versionCheckPromise = versionCheck();
+  const [isNewVersionAvailable, version] = await versionCheckPromise;
+  if (isNewVersionAvailable) {
+    logger.printBox([
+      `There is a new version of @gerdu/cli available (${version}).`,
+      `You are currently using @gerdu/cli ${packageJson.version}`,
+      'Run `yarn global add @gerdu/cli -g` to get latest version',
+    ]);
+  } else {
+    logger.printBox([
+      `You are running the latest version of @gerdu/cli (${version})`,
+    ]);
+  }
+};
+
+export default {
+  run: updateCheckCommand,
+};

--- a/test/app.spec.js
+++ b/test/app.spec.js
@@ -24,6 +24,9 @@ import proxyLsCommand from '@app/commands/proxy/ls-command';
 import proxyDnsCommand from '@app/commands/proxy/dns-command';
 import switchCommand from '@app/commands/workspace/switch-command';
 
+// tool
+import updateCheckCommand from '@app/commands/tool/update-check-command';
+
 const mockOmpletteInit = jest.fn();
 const mockOmletteTree = jest.fn(() => ({ init: mockOmpletteInit }));
 const mockOmletteCleanupShellInitFile = jest.fn();
@@ -258,26 +261,6 @@ describe('app', () => {
       expect(proxyLsCommand.run).toHaveBeenCalledWith();
     });
   });
-  it('notify user with new version', async () => {
-    jest.spyOn(logger, 'printBox').mockImplementation(() => { });
-    jest.spyOn(proxyLsCommand, 'run').mockImplementation(() => { });
-    versionCheck.mockImplementation(() => Promise.resolve([true, '1.0.0']));
-    await app(['node', 'gerdu', 'proxy', 'ls']);
-    expect(versionCheck).toHaveBeenCalled();
-    expect(logger.printBox).toHaveBeenCalledWith([
-      'There is a new version of @gerdu/cli available (1.0.0).',
-      'You are currently using @gerdu/cli 0.0.0',
-      'Run `yarn global add @gerdu/cli -g` to get latest version',
-    ]);
-  });
-  it('wont notify user if no new version is available', async () => {
-    jest.spyOn(logger, 'printBox').mockImplementation(() => { });
-    jest.spyOn(proxyLsCommand, 'run').mockImplementation(() => { });
-    versionCheck.mockImplementation(() => Promise.resolve([false]));
-    await app(['node', 'gerdu', 'proxy', 'ls']);
-    expect(versionCheck).toHaveBeenCalled();
-    expect(logger.printBox).not.toHaveBeenCalledWith();
-  });
   describe('config', () => {
     describe('completion', () => {
       beforeEach(() => {
@@ -306,6 +289,18 @@ describe('app', () => {
       it('setup completion setup', async () => {
         await app(['node', 'gerdu', 'config', 'completion', 'setup']);
         expect(mockOmletteSetupShellInitFile).toHaveBeenCalled();
+      });
+    });
+  });
+  describe('tool', () => {
+    describe('update', () => {
+      beforeEach(() => {
+        jest.spyOn(updateCheckCommand, 'run').mockImplementation(() => { });
+      });
+
+      it('calls update checkk command', async () => {
+        await app(['node', 'gerdu', 'tool', 'update']);
+        expect(updateCheckCommand.run).toHaveBeenCalled();
       });
     });
   });

--- a/test/commands/tool/update-check-command.spec.js
+++ b/test/commands/tool/update-check-command.spec.js
@@ -1,0 +1,32 @@
+/* eslint-disable no-console */
+import logger from '@app/helpers/logger';
+import versionCheck from '@app/helpers/version-check';
+import command from '@app/commands/tool/update-check-command';
+
+versionCheck.mockImplementation(() => Promise.resolve([true, '1.0.0']));
+
+jest.mock('@app/helpers/version-check', () => jest.fn(() => Promise.resolve([false, null])));
+
+describe('view-ls-command', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+  it('new version is available', async () => {
+    jest.spyOn(logger, 'printBox').mockImplementation(() => { });
+    versionCheck.mockImplementation(() => Promise.resolve([true, '1.0.0']));
+    await command.run();
+    expect(logger.printBox).toHaveBeenCalledWith([
+      'There is a new version of @gerdu/cli available (1.0.0).',
+      'You are currently using @gerdu/cli 0.0.0',
+      'Run `yarn global add @gerdu/cli -g` to get latest version',
+    ]);
+  });
+  it('new version is not available', async () => {
+    jest.spyOn(logger, 'printBox').mockImplementation(() => { });
+    versionCheck.mockImplementation(() => Promise.resolve([false, '0.0.0']));
+    await command.run();
+    expect(logger.printBox).toHaveBeenCalledWith([
+      'You are running the latest version of @gerdu/cli (0.0.0)',
+    ]);
+  });
+});


### PR DESCRIPTION
Resolves #51 

As api.npmjs.io is down, we discovered that this failure impacts on other commands. update check moved to it's own command as `gerdu tool update` 

